### PR TITLE
[Fix] Code plain text is now visible

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -1,3 +1,7 @@
 /* @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css); */
 /* @import url(https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css); */
 @import url(https://wet-boew.github.io/wet-boew/theme-wet-boew/css/theme.min.css);
+
+* .token.plain-text {
+  color: #ffffff;
+}


### PR DESCRIPTION
Code plain text is now white so it is visible relative to the background

![image](https://user-images.githubusercontent.com/31704878/149963676-66276141-a7f7-44a1-837a-25e2e8f69b48.png)
