### PR TITLE
[New] Extract styling from project

### DIFF
--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,0 +1,4 @@
+<link
+  rel="stylesheet"
+  href="https://wet-boew.github.io/wet-boew/theme-wet-boew/css/theme.min.css"
+/>

--- a/src/style.css
+++ b/src/style.css
@@ -1,6 +1,6 @@
 /* @import url(https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css); */
 /* @import url(https://wet-boew.github.io/themes-dist/GCWeb/GCWeb/css/theme.min.css); */
-@import url(https://wet-boew.github.io/wet-boew/theme-wet-boew/css/theme.min.css);
+/* @import url(https://wet-boew.github.io/wet-boew/theme-wet-boew/css/theme.min.css); */
 
 .visually-hidden,
 .visually-hidden-focusable:not(:focus):not(:focus-within) {


### PR DESCRIPTION
⭐ **New Features:**
- Moved style sheet to the header of Storybook iframe
- Removed the styling form the core of the component library
- This allows for greater flexibility as the user that imports the library can use their own custom styling. They can choose between GC-Web, WET, or any custom theme that is bootstrap 3 compatible.

📷 **Screenshots:** _(if applicable)_
no screen shot available