### PR TITLE
[Fix] Add Props list to form docs

### DIFF
--- a/src/components/Form/FormControl.tsx
+++ b/src/components/Form/FormControl.tsx
@@ -49,7 +49,7 @@ export interface FormControlProps {
   isRequired?: boolean;
   /** The size attribute of the underlying HTML element. Specifies the visible width in characters if as is 'input'. */
   htmlSize?: number;
-  /** Input size variants */
+  /** Input size variants: 'default', 'sm', 'lg' */
   size?: sizeType;
   /** A callback fired when the value prop changes */
   onChange;

--- a/src/components/Form/FormSelect.tsx
+++ b/src/components/Form/FormSelect.tsx
@@ -16,13 +16,13 @@ export interface FormSelectProps {
   isInvalid?: boolean;
   /** Add "aria-required="true" to input */
   isRequired?: boolean;
-  /** The size attribute of the underlying HTML element. Specifies the number of visible options.. */
+  /** The size attribute of the underlying HTML element. Specifies the number of visible options. */
   htmlSize?: number;
-  /** Input size variants */
+  /** Input size variants: 'default', 'sm', 'lg' */
   size?: sizeType;
   /** A callback fired when the value prop changes */
   onChange;
-  /** Uses controlId from <FormGroup> if not explicitly specified. */
+  /** Uses controlId from <Form.Group> if not explicitly specified. */
   id?: string;
   /** Additional custom classNames */
   className?: string;

--- a/src/components/Form/stories/Form.control.stories.mdx
+++ b/src/components/Form/stories/Form.control.stories.mdx
@@ -187,4 +187,33 @@ The `file` input allows you to upload files.
 
 ### Form.Control Props
 
-**TO BE ADDED**
+**We are working to display the props in a table. Until then, you can find the props below:**
+
+```typescript
+export interface FormControlProps {
+  /** Placeholder content */
+  placeholder?: string;
+  /** The underlying HTML element to use when rendering the FormControl. */
+  as?: asType;
+  /** The HTML input type, which is only relevant if as is 'input' (the default). */
+  type?: typeType;
+  /** Make the control disabled. */
+  isDisabled?: boolean;
+  /** Make the control readonly. */
+  isReadOnly?: boolean;
+  /** Add "aria-invalid="true" to input */
+  isInvalid?: boolean;
+  /** Add "aria-required="true" to input */
+  isRequired?: boolean;
+  /** The size attribute of the underlying HTML element. Specifies the visible width in characters if as is 'input'. */
+  htmlSize?: number;
+  /** Input size variants: 'default', 'sm', 'lg' */
+  size?: sizeType;
+  /** A callback fired when the value prop changes */
+  onChange;
+  /** Uses controlId from <FormGroup> if not explicitly specified. */
+  id?: string;
+  /** Additional custom classNames */
+  className?: string;
+}
+```

--- a/src/components/Form/stories/Form.label.stories.mdx
+++ b/src/components/Form/stories/Form.label.stories.mdx
@@ -40,4 +40,17 @@ import { Form, Button, Alert } from '../..';
 
 ### Form.Label Props
 
-**TO BE ADDED**
+**We are working to display the props in a table. Until then, you can find the props below:**
+
+```typescript
+export interface FormLabelProps {
+  /** Content of button */
+  children?: React.ReactNode;
+  /** Uses controlId from <FormGroup> if not explicitly specified. */
+  htmlFor?: string;
+  /** Hides the label visually while still allowing it to be read by assistive technologies */
+  isVisuallyHidden?: boolean;
+  /** Additional custom classNames */
+  className?: string;
+}
+```

--- a/src/components/Form/stories/Form.select.stories.mdx
+++ b/src/components/Form/stories/Form.select.stories.mdx
@@ -66,4 +66,29 @@ By setting the `htmlSize` you can define the number of visible lines
 
 ### Form.Select Props
 
-**TO BE ADDED**
+**We are working to display the props in a table. Until then, you can find the props below:**
+
+```typescript
+export interface FormSelectProps {
+  /** Content of button */
+  children?: React.ReactNode;
+  /** Placeholder content */
+  placeholder?: string;
+  /** Make the control disabled. */
+  isDisabled?: boolean;
+  /** Add "aria-invalid="true" to input */
+  isInvalid?: boolean;
+  /** Add "aria-required="true" to input */
+  isRequired?: boolean;
+  /** The size attribute of the underlying HTML element. Specifies the number of visible options. */
+  htmlSize?: number;
+  /** Input size variants: 'default', 'sm', 'lg' */
+  size?: sizeType;
+  /** A callback fired when the value prop changes */
+  onChange;
+  /** Uses controlId from <Form.Group> if not explicitly specified. */
+  id?: string;
+  /** Additional custom classNames */
+  className?: string;
+}
+```

--- a/src/components/Form/stories/Form.text.stories.mdx
+++ b/src/components/Form/stories/Form.text.stories.mdx
@@ -67,4 +67,17 @@ The `isMuted` prop can be used to mute the text styling. It defaults to `true`.
 
 ### Form.Text Props
 
-**TO BE ADDED**
+**We are working to display the props in a table. Until then, you can find the props below:**
+
+```typescript
+export interface FormTextProps {
+  /** Content of button */
+  children?: React.ReactNode;
+  /** A convenience prop for add the text-muted class, since it's so commonly used here. */
+  isMuted?: boolean;
+  /** Hides the label visually while still allowing it to be read by assistive technologies */
+  visuallyHidden?: boolean;
+  /** Additional custom classNames */
+  className?: string;
+}
+```


### PR DESCRIPTION
⭐ **New Features:**

- add props list to form docs
- ⚠️ this is a temporary solution until we can get prop tables to work for sub components

📷 **Screenshots:** _(if applicable)_
example:
<img width="1020" alt="Screen Shot 2022-02-09 at 11 57 17 PM" src="https://user-images.githubusercontent.com/11470442/153340092-f4337355-34b7-4011-b168-f45aa01e613d.png">

