### PR TITLE
[Fix] Extend the input types to include the correct props for the html element

### DIFF
--- a/src/components/Alert/Alert.tsx
+++ b/src/components/Alert/Alert.tsx
@@ -4,7 +4,7 @@ import '../../style.css';
 /** Types */
 type variantType = 'success' | 'warning' | 'danger' | 'info' | undefined;
 
-export interface AlertProps {
+export interface AlertProps extends React.HTMLAttributes<HTMLDivElement> {
   /** The styling variant that you would like to use */
   variant?: variantType;
   /** Show alert */

--- a/src/components/Alert/AlertBody.tsx
+++ b/src/components/Alert/AlertBody.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-export interface AlertBodyProps {
+export interface AlertBodyProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Content of alert body */
   children?: React.ReactNode;
   /** Additional custom classNames */

--- a/src/components/Alert/AlertHeader.tsx
+++ b/src/components/Alert/AlertHeader.tsx
@@ -3,7 +3,7 @@ import Title from '@components/Title';
 
 type levelType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | undefined;
 
-export interface AlertHeaderProps {
+export interface AlertHeaderProps extends React.HTMLAttributes<HTMLElement> {
   /** Content of alert heading */
   children?: React.ReactNode;
   /** Header Level */

--- a/src/components/Alert/AlertLink.tsx
+++ b/src/components/Alert/AlertLink.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-export interface AlertLinkProps {
+export interface AlertLinkProps
+  extends React.HTMLAttributes<HTMLAnchorElement> {
   /** Content of alert Link */
   children?: React.ReactNode;
   /** The target of hyperlink */

--- a/src/components/Badge/Badge.tsx
+++ b/src/components/Badge/Badge.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import '../../style.css';
 
-export interface BadgeProps {
+export interface BadgeProps extends React.HTMLAttributes<HTMLElement> {
   /** Hidden label describing the badge */
   badgeLabel?: string;
   /** Hidden label describing the badge */

--- a/src/components/Button/Button.tsx
+++ b/src/components/Button/Button.tsx
@@ -18,7 +18,8 @@ type sizingType = 'lg' | 'sm' | 'xs' | undefined;
 type typeType = 'submit' | 'button' | 'reset' | undefined;
 type asType = 'input';
 
-export interface ButtonProps {
+export interface ButtonProps
+  extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   /** Content of button */
   children?: React.ReactNode;
   /** The styling variant that you would like to use */

--- a/src/components/Button/stories/Button.intro.stories.mdx
+++ b/src/components/Button/stories/Button.intro.stories.mdx
@@ -16,4 +16,9 @@ Use buttons to create a call to action that entices the user to submit content f
 
 ## Available Props
 
+The `<Button>` component accepts all of the default props for the `button` HTML element in addition to the ones in the table below.
+
+More info about the HTML element:<br/>
+https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement
+
 <ArgsTable component="Button" />

--- a/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/src/components/ButtonGroup/ButtonGroup.tsx
@@ -5,7 +5,7 @@ import '../../style.css';
 /** Types */
 type sizingType = 'lg' | 'sm' | undefined;
 
-export interface ButtonGroupProps {
+export interface ButtonGroupProps extends React.HTMLAttributes<HTMLElement> {
   /** The custom 'non-default' size of button group */
   size?: sizingType;
   /** Orientation of button group */

--- a/src/components/CodeBlock/CodeBlock.tsx
+++ b/src/components/CodeBlock/CodeBlock.tsx
@@ -3,7 +3,7 @@ import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter';
 import { a11yDark } from 'react-syntax-highlighter/dist/cjs/styles/prism';
 import '../../style.css';
 
-export interface CodeBlockProps {
+export interface CodeBlockProps extends React.HTMLAttributes<HTMLElement> {
   /** the language to highlight code in. (pass text to just render plain monospaced text) */
   language?: string;
   /** prop that will be combined with the top level style on the `pre` tag, styles here will overwrite earlier styles. */

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FormRB from 'react-bootstrap/Form';
 import '../../style.css';
 
-export interface FormProps {
+export interface FormProps extends React.FormHTMLAttributes<HTMLFormElement> {
   /** Content of Form */
   children?: React.ReactNode;
   /** Additional custom classNames */

--- a/src/components/Form/FormCheck.tsx
+++ b/src/components/Form/FormCheck.tsx
@@ -5,7 +5,8 @@ import '../../style.css';
 /** Types */
 type typeType = 'checkbox' | 'radio' | 'switch' | undefined;
 
-export interface FormCheckProps {
+export interface FormCheckProps
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   /** title attribute */
   title?: string;
   /** label attribute */

--- a/src/components/Form/FormControl.tsx
+++ b/src/components/Form/FormControl.tsx
@@ -34,7 +34,8 @@ type typeType =
 
 type FormControlElement = HTMLInputElement | HTMLTextAreaElement;
 
-export interface FormControlProps {
+export interface FormControlProps
+  extends React.HTMLAttributes<FormControlElement> {
   /** Placeholder content */
   placeholder?: string;
   /** The underlying HTML element to use when rendering the FormControl. */

--- a/src/components/Form/FormGroup.tsx
+++ b/src/components/Form/FormGroup.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FormRB from 'react-bootstrap/Form';
 import '../../style.css';
 
-export interface FormGroupProps {
+export interface FormGroupProps extends React.HTMLAttributes<HTMLElement> {
   /** Content of button */
   children?: React.ReactNode;
   /** Unique Id of form group elements */

--- a/src/components/Form/FormLabel.tsx
+++ b/src/components/Form/FormLabel.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FormRB from 'react-bootstrap/Form';
 import '../../style.css';
 
-export interface FormLabelProps {
+export interface FormLabelProps extends React.HTMLAttributes<HTMLElement> {
   /** Content of button */
   children?: React.ReactNode;
   /** Uses controlId from <FormGroup> if not explicitly specified. */

--- a/src/components/Form/FormSelect.tsx
+++ b/src/components/Form/FormSelect.tsx
@@ -5,7 +5,8 @@ import '../../style.css';
 /** Types */
 type sizeType = 'lg' | 'sm' | 'default' | undefined;
 
-export interface FormSelectProps {
+export interface FormSelectProps
+  extends Omit<React.SelectHTMLAttributes<HTMLSelectElement>, 'size'> {
   /** Content of button */
   children?: React.ReactNode;
   /** Placeholder content */

--- a/src/components/Form/FormText.tsx
+++ b/src/components/Form/FormText.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import FormRB from 'react-bootstrap/Form';
 import '../../style.css';
 
-export interface FormTextProps {
+export interface FormTextProps extends React.HTMLAttributes<HTMLElement> {
   /** Content of button */
   children?: React.ReactNode;
   /** A convenience prop for add the text-muted class, since it's so commonly used here. */

--- a/src/components/Form/stories/Form.check.stories.mdx
+++ b/src/components/Form/stories/Form.check.stories.mdx
@@ -72,6 +72,11 @@ Group checkboxes or radios on the same horizontal row by adding the `isInline` p
 
 ### Form.Select Props
 
+The `<Form.Check>` component accepts all of the default props for the `check` HTML element in addition to the ones in the table below.
+
+More info about the HTML element:<br/>
+https://developer.mozilla.org/en-US/docs/Web/API/HTMLInputElement
+
 **We are working to display the props in a table. Until then, you can find the props below:**
 
 ```typescript

--- a/src/components/Form/stories/Form.intro.stories.mdx
+++ b/src/components/Form/stories/Form.intro.stories.mdx
@@ -32,4 +32,9 @@ The `<Form.Control>` component renders a form control with Bootstrap styling. Th
 
 ## Form Props
 
+The `<Form>` component accepts all of the default props for the `form` HTML element in addition to the ones in the table below.
+
+More info about the HTML element:<br/>
+https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
+
 <ArgsTable />

--- a/src/components/Form/stories/Form.intro.stories.mdx
+++ b/src/components/Form/stories/Form.intro.stories.mdx
@@ -35,6 +35,6 @@ The `<Form.Control>` component renders a form control with Bootstrap styling. Th
 The `<Form>` component accepts all of the default props for the `form` HTML element in addition to the ones in the table below.
 
 More info about the HTML element:<br/>
-https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form
+https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement
 
 <ArgsTable />

--- a/src/components/Form/stories/Form.select.stories.mdx
+++ b/src/components/Form/stories/Form.select.stories.mdx
@@ -66,6 +66,11 @@ By setting the `htmlSize` you can define the number of visible lines
 
 ### Form.Select Props
 
+The `<Form.Select>` component accepts all of the default props for the `select` HTML element in addition to the ones in the table below.
+
+More info about the HTML element:<br/>
+https://developer.mozilla.org/en-US/docs/Web/API/HTMLSelectElement
+
 **We are working to display the props in a table. Until then, you can find the props below:**
 
 ```typescript

--- a/src/components/Label/Label.tsx
+++ b/src/components/Label/Label.tsx
@@ -11,7 +11,7 @@ type variantType =
   | 'info'
   | undefined;
 
-export interface LabelProps {
+export interface LabelProps extends React.HTMLAttributes<HTMLElement> {
   /** Hidden label describing the badge */
   variant?: variantType;
   /** Hidden label describing the badge */

--- a/src/components/Link/Link.tsx
+++ b/src/components/Link/Link.tsx
@@ -4,7 +4,7 @@ import '../../style.css';
 type targetType = '_blank' | '_self' | '_parent' | '_top' | undefined;
 
 /** Types */
-export interface LinkProps {
+export interface LinkProps extends React.HTMLAttributes<HTMLAnchorElement> {
   /** Content of heading */
   children?: React.ReactNode;
   /** The target of hyperlink */

--- a/src/components/Panel/Panel.tsx
+++ b/src/components/Panel/Panel.tsx
@@ -6,7 +6,7 @@ import '../../style.css';
 type variantType = 'success' | 'warning' | 'danger' | 'info' | undefined;
 type headingLevelType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | undefined;
 
-export interface PanelProps {
+export interface PanelProps extends React.HTMLAttributes<HTMLElement> {
   /** The styling variant that you would like to use */
   variant?: variantType;
   /** The content of panel header */

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import ProgressBarRB from 'react-bootstrap/ProgressBar';
 import '../../style.css';
 
-export interface ProgressBarProps {
+export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
   /** Show label that represents visual percentage. EG. 60% */
   label?: React.ReactNode;
   /** Hide's the label visually. */

--- a/src/components/Text/Text.tsx
+++ b/src/components/Text/Text.tsx
@@ -21,7 +21,7 @@ type backgroundType =
 
 type sizeType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | undefined;
 
-export interface TextProps {
+export interface TextProps extends React.HTMLAttributes<HTMLElement> {
   /** Content of heading */
   children?: React.ReactNode;
   /** Text color */

--- a/src/components/Title/Title.tsx
+++ b/src/components/Title/Title.tsx
@@ -4,7 +4,7 @@ import '../../style.css';
 /** Types */
 type levelType = 'h1' | 'h2' | 'h3' | 'h4' | 'h5' | 'h6' | undefined;
 
-export interface TitleProps {
+export interface TitleProps extends React.HTMLAttributes<HTMLElement> {
   /** Content of heading */
   children?: React.ReactNode;
   /** Heading level */


### PR DESCRIPTION
⭐ **New Features:**

- the spreading operator was not working correctly for the props because Typescript needed explicitly define props. example: onSubmit for forms.
- By extending the correct types we resolve this issue

ℹ️ **Related Issues:**

no related tickets

📷 **Screenshots:** _(if applicable)_

no visual change