### PR TITLE
[Fix] improper use of `value` prop for radio.check

### DIFF
--- a/src/components/Form/FormCheck.tsx
+++ b/src/components/Form/FormCheck.tsx
@@ -6,7 +6,7 @@ import '../../style.css';
 type typeType = 'checkbox' | 'radio' | 'switch' | undefined;
 
 export interface FormCheckProps
-  extends Omit<React.InputHTMLAttributes<HTMLInputElement>, 'value'> {
+  extends React.InputHTMLAttributes<HTMLInputElement> {
   /** title attribute */
   title?: string;
   /** label attribute */
@@ -21,8 +21,6 @@ export interface FormCheckProps
   isInvalid?: boolean;
   /** Add "aria-required="true" to input */
   isRequired?: boolean;
-  /** The status of checkbox (True/False) */
-  value?: boolean;
   /** Uses controlId from <FormGroup> if not explicitly specified. */
   id?: string;
   /** Additional custom classNames */
@@ -39,7 +37,6 @@ const FormCheck = React.forwardRef(
       isInline = false,
       isInvalid = false,
       isRequired = false,
-      value = false,
       id,
       className = '',
       ...rest
@@ -52,7 +49,6 @@ const FormCheck = React.forwardRef(
       type={type}
       disabled={isDisabled}
       inline={isInline}
-      checked={value}
       aria-required={isRequired}
       aria-invalid={isInvalid}
       ref={ref}

--- a/src/components/Form/stories/Form.check.stories.mdx
+++ b/src/components/Form/stories/Form.check.stories.mdx
@@ -15,12 +15,20 @@ For the non-textual checkbox and radio controls, FormCheck provides a single com
 <Canvas>
   <Story name="Default">
     <Form>
-      <Form.Check type="checkbox" label={`default checkbox 1`} />
-      <Form.Check type="checkbox" label={`default checkbox 2`} />
+      <Form.Check
+        type="checkbox"
+        label={`default checkbox 1`}
+        value="checkbox-1"
+      />
+      <Form.Check
+        type="checkbox"
+        label={`default checkbox 2`}
+        value="checkbox-1"
+      />
     </Form>
     <Form>
-      <Form.Check type="radio" label={`default radio 1`} />
-      <Form.Check type="radio" label={`default radio 2`} />
+      <Form.Check type="radio" label={`default radio 1`} value="radio-1" />
+      <Form.Check type="radio" label={`default radio 2`} value="radio-1" />
     </Form>
   </Story>
 </Canvas>


### PR DESCRIPTION
⭐ **New Features:**

- remove the defined `value` prop as `<checkbox>` and `<radio>` use `value` to define the value of the field is it is checked.

ℹ️ **Related Issues:**

no related issues

📷 **Screenshots:** _(if applicable)_

no visual chaage