### PR TITLE
[Fix] set the `title` type for `<Detail>` as react-node

### DIFF
--- a/src/components/Details/Details.tsx
+++ b/src/components/Details/Details.tsx
@@ -1,9 +1,8 @@
 import React, { ReactNode } from 'react';
-import '../../style.css';
 
 type detailData = {
   key: string;
-  title: string;
+  title: ReactNode;
   children: ReactNode;
   className?: string;
 };

--- a/src/components/Details/stories/Details.intro.stories.mdx
+++ b/src/components/Details/stories/Details.intro.stories.mdx
@@ -44,7 +44,7 @@ The general structure of `data` is defined as follows:
 ```js
 data = [{
   key: string;
-  title: string;
+  title: ReactNode;
   children: ReactNode;
   className?: string;
 }]


### PR DESCRIPTION
⭐ **New Features:**

- set the `title` type for `<Detail>` as react-node

ℹ️ **Related Issues:**

no related issue

📷 **Screenshots:** _(if applicable)_

no visual change
