### PR TITLE
[Fix] Added isChild prop to 'ProgressBar'

### DIFF
--- a/src/components/ProgressBar/ProgressBar.test.tsx
+++ b/src/components/ProgressBar/ProgressBar.test.tsx
@@ -201,4 +201,78 @@ describe('ProgressBar Tests', () => {
       expect(screen.getByText(labelPlaceholder)).toHaveClass('visually-hidden');
     });
   });
+
+  describe('ProgressBar isChild Tests', () => {
+    const labelPlaceholder = 'test 1234';
+
+    test('test isChild enabled', () => {
+      const result = render(
+        <ProgressBar
+          now={30}
+          min={20}
+          max={40}
+          label={labelPlaceholder}
+          isChild
+        />
+      );
+
+      expect(result.container.querySelector('.progress')).toBeNull();
+      expect(
+        result.container.querySelector('.progress-bar')
+      ).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'aria-valuemin',
+        '20'
+      );
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'aria-valuemax',
+        '40'
+      );
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'aria-valuenow',
+        '30'
+      );
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'style',
+        'width: 50%;'
+      );
+      expect(screen.getByText(labelPlaceholder)).not.toHaveClass(
+        'visually-hidden'
+      );
+    });
+
+    test('test isChild disabled', () => {
+      const result = render(
+        <ProgressBar
+          now={30}
+          min={20}
+          max={40}
+          label={labelPlaceholder}
+          isLabelHidden
+          isChild={false}
+        />
+      );
+
+      expect(result.container.querySelector('.progress')).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toBeInTheDocument();
+      expect(screen.getByRole('progressbar')).toHaveClass('progress-bar');
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'aria-valuemin',
+        '20'
+      );
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'aria-valuemax',
+        '40'
+      );
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'aria-valuenow',
+        '30'
+      );
+      expect(screen.getByRole('progressbar')).toHaveAttribute(
+        'style',
+        'width: 50%;'
+      );
+      expect(screen.getByText(labelPlaceholder)).toHaveClass('visually-hidden');
+    });
+  });
 });

--- a/src/components/ProgressBar/ProgressBar.tsx
+++ b/src/components/ProgressBar/ProgressBar.tsx
@@ -15,6 +15,8 @@ export interface ProgressBarProps extends React.HTMLAttributes<HTMLDivElement> {
   now?: number;
   /** Additional custom classNames */
   className?: string;
+  /** Indicates whether the element is a child member or not */
+  isChild?: boolean;
 }
 
 const ProgressBar = ({
@@ -24,6 +26,7 @@ const ProgressBar = ({
   min = 0,
   now = 0,
   className,
+  isChild = false,
   ...rest
 }: ProgressBarProps) => {
   const sterilizedMin = min > max ? max : min;
@@ -38,6 +41,7 @@ const ProgressBar = ({
       min={sterilizedMin}
       now={sterilizedNow}
       className={className}
+      isChild={isChild}
       {...rest}
     />
   );

--- a/src/components/ProgressBar/stories/ProgressBar.label.stories.mdx
+++ b/src/components/ProgressBar/stories/ProgressBar.label.stories.mdx
@@ -33,7 +33,13 @@ The label is optional and can be omitted
 <Canvas>
   <Story
     name="Screenreader only label"
-    args={{ now: 60, label: '60%', visuallyHidden: true }}
+    args={{
+      now: 60,
+      label: '60%',
+      visuallyHidden: true,
+      isChild: true,
+      'aria-label': '60%',
+    }}
   >
     {Template.bind({})}
   </Story>


### PR DESCRIPTION
⭐ **New Features:**

- Added isChild prop to the 'ProgressBar' component since that is the only way to pass an aria-label

ℹ️ **Related Issues:**

n/a

📷 **Screenshots:**
![image](https://user-images.githubusercontent.com/47506745/166566714-2ae23f76-0394-4bf8-82fb-7d97e09cc565.png)

